### PR TITLE
added length limit to error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ module.exports = function parseError(err) {
     if (err.stack) {
         return err.stack
     }
+    if (err.response){
+        return err.response;
+    }
     // in a hdfs error it can return the entire data set so we make sure to only take up to 5k chars
-    return err.response ? err.response : err.slice(0,5000);
+    return err.length >= 5000 ? `${err.slice(0,5000)} ...` : err;
 };

--- a/index.js
+++ b/index.js
@@ -22,5 +22,6 @@ module.exports = function parseError(err) {
     if (err.stack) {
         return err.stack
     }
-    return err.response ? err.response : err;
+    // in a hdfs error it can return the entire data set so we make sure to only take up to 5k chars
+    return err.response ? err.response : err.slice(0,5000);
 };

--- a/spec/module-spec.js
+++ b/spec/module-spec.js
@@ -68,4 +68,19 @@ describe('error_parser', () => {
         expect(errorParser(errorData)).toEqual(expectedErrorMsg)
     })
 
+    it('will truncate error messages to 5k length', () => {
+        const msg = 'i am a elasticsearch error';
+        let longErrorMsg = '';
+
+        while (longErrorMsg.length < 5000){
+            longErrorMsg += 'a';
+        }
+
+        expect(errorParser(msg)).toEqual(msg)
+        expect(errorParser(msg).length).toEqual(msg.length)
+
+        expect(errorParser(longErrorMsg)).toEqual(`${longErrorMsg} ...`);
+        expect(errorParser(longErrorMsg).length).toEqual(longErrorMsg.length + 4)
+    })
+
 });

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
I set the limit of chars a regular error message can be passed on to 5k chars
